### PR TITLE
fixed Faraday::Error::ClientError

### DIFF
--- a/diffbot-ruby-client.gemspec
+++ b/diffbot-ruby-client.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'guard-rspec'
 
-  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday', '~> 0.17.3'
 end


### PR DESCRIPTION
Faraday::Error::ClientError was renamed to Faraday::ClientError in some later version of Faraday.  Faraday gem needed to be fixed to an older version in the .gemspec file.